### PR TITLE
Detect processes which fail before their readiness check

### DIFF
--- a/integration/internal/integration_tests/etcd_integration_test.go
+++ b/integration/internal/integration_tests/etcd_integration_test.go
@@ -50,17 +50,12 @@ var _ = Describe("Etcd", func() {
 		stdout := &bytes.Buffer{}
 		stderr := &bytes.Buffer{}
 		etcd := &Etcd{
-			Args:         []string{"--help"},
+			Args:         []string{"--name", "xyzxyz"},
 			Out:          stdout,
 			Err:          stderr,
-			StartTimeout: 500 * time.Millisecond,
+			StartTimeout: 5 * time.Second,
 		}
-
-		// it will timeout, as we'll never see the "startup message" we are waiting
-		// for on StdErr
-		Expect(etcd.Start()).To(MatchError(ContainSubstring("timeout")))
-
-		Expect(stdout.String()).To(ContainSubstring("member flags"))
-		Expect(stderr.String()).To(ContainSubstring("usage: etcd"))
+		Expect(etcd.Start()).To(Succeed())
+		Expect(stderr.String()).To(ContainSubstring("Name:xyzxyz"))
 	})
 })

--- a/integration/internal/process.go
+++ b/integration/internal/process.go
@@ -140,6 +140,8 @@ func (ps *ProcessState) Start(stdout, stderr io.Writer) (err error) {
 	}
 
 	select {
+	case <-ps.Session.Exited:
+		return fmt.Errorf("process %s exited before readiness with exit code %d", path.Base(ps.Path), ps.Session.ExitCode())
 	case <-ready:
 		ps.ready = true
 		return nil

--- a/integration/internal/process_test.go
+++ b/integration/internal/process_test.go
@@ -39,6 +39,16 @@ var _ = Describe("Start method", func() {
 		Consistently(processState.Session.ExitCode).Should(BeNumerically("==", -1))
 	})
 
+	It("handles process startup failures ", func() {
+		processState.StartTimeout = 10 * time.Second
+		processState.StartMessage = "unlikely-stderr-message"
+		processState.Args = []string{"-c", "exit 5"}
+
+		err := processState.Start(nil, nil)
+		Expect(err).To(MatchError("process bash exited before readiness with exit code 5"))
+		Expect(processState.Session.ExitCode()).To(BeNumerically("==", 5))
+	})
+
 	Context("when a health check endpoint is provided", func() {
 		var server *ghttp.Server
 		BeforeEach(func() {

--- a/integration/internal/process_test.go
+++ b/integration/internal/process_test.go
@@ -216,6 +216,7 @@ var _ = Describe("Start method", func() {
 					echo 'this is stderr' >&2
 					echo 'that is stdout'
 					echo 'i started' >&2
+					sleep infinity
 				`,
 			}
 			processState.StartMessage = "i started"


### PR DESCRIPTION
Wait on the starting process incase it fails before the readiness check.